### PR TITLE
Fixed endian problems and parsing of microseconds when reading in DLT file

### DIFF
--- a/dltpy/dltfile.py
+++ b/dltpy/dltfile.py
@@ -74,7 +74,7 @@ class DltMessage:
         if raw.msg.hdr.has_tmsp:
             self.ts = raw.msg.hdr.tmsp * 1e-4
 
-        self.date = raw.storage_hdr.ts_sec + (raw.storage_hdr.ts_msec * 1e-3)
+        self.date = raw.storage_hdr.ts_sec + (raw.storage_hdr.ts_msec * 1e-6)
         self.raw_payload = raw.msg.payload
 
     def __str__(self):

--- a/dltpy/gen/stored_message.py
+++ b/dltpy/gen/stored_message.py
@@ -28,7 +28,7 @@ class StoredMessage(KaitaiStruct):
         def _read(self):
             self.magic = self._io.ensure_fixed_contents(b"\x44\x4C\x54\x01")
             self.ts_sec = self._io.read_u4le()
-            self.ts_msec = self._io.read_u4le()
+            self.ts_msec = self._io.read_s4le()
             self.ecu_id = (self._io.read_bytes(4)).decode(u"ascii")
 
 

--- a/dltpy/gen/stored_message.py
+++ b/dltpy/gen/stored_message.py
@@ -27,8 +27,8 @@ class StoredMessage(KaitaiStruct):
 
         def _read(self):
             self.magic = self._io.ensure_fixed_contents(b"\x44\x4C\x54\x01")
-            self.ts_sec = self._io.read_u4be()
-            self.ts_msec = self._io.read_u4be()
+            self.ts_sec = self._io.read_u4le()
+            self.ts_msec = self._io.read_u4le()
             self.ecu_id = (self._io.read_bytes(4)).decode(u"ascii")
 
 


### PR DESCRIPTION
storage_hdr.ts_msec are microseconds (1e-6), not milliseconds.

Also, read in the values as little-endian values.