### PR TITLE
Add support for Windows (MSVC)

### DIFF
--- a/dltpy/native/CMakeLists.txt
+++ b/dltpy/native/CMakeLists.txt
@@ -37,15 +37,22 @@ target_include_directories(dltreader_native
     ${PYTHON_INCLUDE_DIR}
 )
 target_link_libraries(dltreader_native
-    ${PYTHON_LIBRARY}
+    ${PYTHON_LIBRARIES}
     fmt::fmt
     pybind11::pybind11
 )
+
+if(WIN32)
+    set(suffix ".pyd")
+else()
+    set(suffix ".so")
+endif()
+
 set_target_properties(
     dltreader_native
     PROPERTIES
         PREFIX ""
-        SUFFIX ".so"
+        SUFFIX ${suffix}
         OUTPUT_NAME dltreader_native
         LINKER_LANGUAGE C
     )

--- a/dltpy/native/dltreader.cpp
+++ b/dltpy/native/dltreader.cpp
@@ -22,8 +22,6 @@
 #include "bitmasks.h"
 #include "parsers.h"
 #include "headers.h"
-#include <fcntl.h>
-#include <unistd.h>
 #include <cassert>
 #include <vector>
 #include "dltreader.h"
@@ -80,15 +78,15 @@ DltReader::DltReader(bool expectStorage)
 
 std::string DltReader::str(){
     return fmt::format("DltReader(buf={:p}, msg={:p}, data end={:p})",
-                       iBuffer.begin(),
+                       iBuffer.data(),
                        iMessageBegin,
                        iDataEnd
         );
 }
 
 void DltReader::selfcheck(){
-    assert(iMessageBegin >= iBuffer.begin() && iMessageBegin <= iDataEnd);
-    assert(iDataEnd >= iBuffer.begin() && iDataEnd <= iBuffer.end());
+    assert(iMessageBegin >= iBuffer.data() && iMessageBegin <= iDataEnd);
+    assert(iDataEnd >= iBuffer.data() && iDataEnd <= &(*iBuffer.end()));
 }
 
 off_t DltReader::dataLeft(){
@@ -107,8 +105,8 @@ void DltReader::consumeMessage(){
 
 void DltReader::flush(){
     selfcheck();
-    auto shift = iMessageBegin - iBuffer.begin();
-    iDataEnd = std::copy(iMessageBegin, iDataEnd, iBuffer.begin());
+    auto shift = iMessageBegin - iBuffer.data();
+    iDataEnd = std::copy(iMessageBegin, iDataEnd, iBuffer.data());
     iCursor -= shift;
     iMessageBegin -= shift;
     selfcheck();

--- a/dltpy/native/dltreader.h
+++ b/dltpy/native/dltreader.h
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "headers.h"
+#include <stdexcept>
 #include <vector>
 #include <optional>
 #include <tuple>
@@ -48,9 +49,9 @@ class DltReader{
 
     std::array<char, 8196> iBuffer;
         
-    char* iDataEnd{iBuffer.begin()};
-    char* iCursor{iBuffer.begin()};
-    char* iMessageBegin{iBuffer.begin()};
+    char* iDataEnd{iBuffer.data()};
+    char* iCursor{iBuffer.data()};
+    char* iMessageBegin{iBuffer.data()};
 
     off_t iBasicOffset{0};
     off_t iPayloadOffset{0};
@@ -75,7 +76,7 @@ public:
     void consumeMessage();
     void flush();
 
-    std::tuple<char*, size_t> getBuffer(){flush(); return {iDataEnd, iBuffer.end() - iDataEnd};}
+    std::tuple<char*, size_t> getBuffer(){flush(); return {iDataEnd, &(*iBuffer.end()) - iDataEnd};}
     void updateBuffer(size_t len){iDataEnd += len;}
         
     const StorageHeader& getStorage() const{

--- a/dltpy/native/dltreader_native.cpp
+++ b/dltpy/native/dltreader_native.cpp
@@ -8,7 +8,7 @@ namespace py=pybind11;
 template<size_t N>
 auto pyArrayStringToBytes(const std::array<char, N>& arr){
     off_t len = std::find(arr.begin(), arr.end(), '\0') - arr.begin();
-    return py::bytes(arr.begin(), len);
+    return py::bytes(arr.data(), len);
 }
 
 template<size_t N>


### PR DESCRIPTION
**Prerequirements**
MSVC (only Build Tools), CMake, Ninja

**Steps to build**
All commands have to be executed in a "MSVC Native Tools Command Prompt" to get the compiler settings.

* Download or clone fmt
* Create a build directory for fmt and go to the build directory
* set CC=CL
* set CXX=CL
* cmake -G Ninja -DCMAKE_INSTALL_PREFIX=path\to\fmt\installation -DCMAKE_BUILD_TYPE=Release path\to\fmt\source
* ninja install

* set CMAKE_PREFIX_PATH=path\to\fmt\installation 
* set CMAKE_GENERATOR=Ninja
* pip install --user -e path\to\dltpy\source

**Notes**
* I had to write the setup.py to get the pathes correct. I am not sure if all the changes are necessary but I took the code from here:
https://stackoverflow.com/questions/42585210/extending-setuptools-extension-to-use-cmake-in-setup-py 
* I was not able to select C++17 without using the Ninja generator
* I have not tested if the modifications break the Linux build.